### PR TITLE
Fix valid viewpoint_id 0 being skipped in spatial target VLM queries

### DIFF
--- a/src/vlm_node/vlm_node/vlm_reasoning_node.py
+++ b/src/vlm_node/vlm_node/vlm_reasoning_node.py
@@ -892,12 +892,15 @@ class VLMNode(Node):
         viewpoint_imgs = []
         viewpoint_img_bases = []
         for vp_id in viewpoint_ids:
-            if vp_id <= 0:
+            if vp_id < 0:
                 continue
             vp_image_path = os.path.join(self.viewpoint_path, f"viewpoint_{vp_id}.png")
             vp_pose_path = os.path.join(self.viewpoint_path, f"viewpoint_{vp_id}_transform.npy")
             if not os.path.exists(vp_image_path):
                 self.get_logger().warning(f"Viewpoint image {vp_image_path} does not exist")
+                continue
+            if not os.path.exists(vp_pose_path):
+                self.get_logger().warning(f"Viewpoint pose {vp_pose_path} does not exist")
                 continue
             viewpoint_image = cv2.imread(vp_image_path)
             viewpoint_transform_matrix = np.load(vp_pose_path)


### PR DESCRIPTION
This PR fixes a bug in the spatial target-object VLM query pipeline where a valid viewpoint with ID 0 was incorrectly skipped.

Before:
- `viewpoint_ids = [0]` resulted in no additional viewpoint image being used.
- The VLM often received only the object crop for spatial reasoning.

After:
- `viewpoint_ids = [0]` correctly includes `viewpoint_0`.
- Valid zero-indexed viewpoints are preserved for spatial VLM reasoning.
